### PR TITLE
Fixed requiring files from lib directory ( NameError: uninitialized constant ComposableStateMachine::CallbackRunner)

### DIFF
--- a/lib/composable_state_machine.rb
+++ b/lib/composable_state_machine.rb
@@ -1,5 +1,4 @@
-Dir['lib/composable_state_machine/**/*.rb'].each { |f| require File.expand_path(f) }
-
+Gem.find_files("composable_state_machine/**/*.rb").each { |path| require path }
 # @author {https://github.com/ssimeonov Simeon Simeonov}, {http://swoop.com Swoop, Inc.}
 #
 # For examples, see the {file:README.html README}.


### PR DESCRIPTION
Hello, 
   First of all i want to thank you for such a great job. I love this gem . 
  I tried using it in one of my projects and i kept getting errors like 
 " NameError: uninitialized constant ComposableStateMachine::CallbackRunner " and also this happenned for all other files 
although this was my code that i was using:

```
require 'composable_state_machine'
class Room
  MACHINE_MODEL = ComposableStateMachine.model(
      transitions: {
          heat: {cold: :warm, warm: :hot},
          cool: {warm: :cold, hot: :warm},
      }
  )

  attr_reader :temp

  def initialize(temp)
    @machine = ComposableStateMachine::MachineWithExternalState.new(
        MACHINE_MODEL, method(:temp), method(:temp=), state: temp)
  end

  def heat(periods = 1)
    periods.times { @machine.trigger(:heat) }
    self
  end

  def cool(periods = 1)
    periods.times { @machine.trigger(:cool) }
    self
  end

  private

  def temp=(new_value)
    puts " -- Temperature changed from #{temp.inspect} to #{new_value.inspect}"
    @temp = new_value
  end
end

```

But after changing how the files are being required from the lib directory, now everything works fine. 
Let me know if it is ok or you need me to change something. Thanks. 
